### PR TITLE
Fix serving images in splitguides-server

### DIFF
--- a/src/splitguides/server/__main__.py
+++ b/src/splitguides/server/__main__.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 from PySide6.QtWidgets import QApplication, QMainWindow
 import waitress
 
 from splitguides.server import app, get_notes, settings
+from splitguides.server import split_server
+
 from splitguides.ui.server_settings_ui import ServerSettingsDialog
 
 
@@ -30,9 +34,14 @@ def launch():
     print(
         "This server version of SplitGuides allows you view notes via a browser window "
         "and should work across a local network.\n"
-        "This uses a development server and is not intended "
-        "to be used over the internet."
+        "This is not intended to be used over the internet or on public networks."
     )
+
+    # Access via split_server as this value gets replaced only after get_notes
+    assert isinstance(split_server.notefile, Path)  # True due to success of get_notes
+    notefolder = Path(split_server.notefile).parent
+
+    print(f"Serving data from '{notefolder}' for local files")
 
     print(
         f"Connect a browser to "

--- a/src/splitguides/server/__main__.py
+++ b/src/splitguides/server/__main__.py
@@ -41,7 +41,7 @@ def launch():
     assert isinstance(split_server.notefile, Path)  # True due to success of get_notes
     notefolder = Path(split_server.notefile).parent
 
-    print(f"Serving data from '{notefolder}' for local files")
+    print(f"Serving contents of '{notefolder}' for relative links")
 
     print(
         f"Connect a browser to "

--- a/src/splitguides/server/split_server.py
+++ b/src/splitguides/server/split_server.py
@@ -4,7 +4,7 @@ import string
 import time
 from pathlib import Path
 
-from flask import Flask, render_template, Response
+from flask import Flask, Response, render_template, send_from_directory
 from PySide6.QtWidgets import QFileDialog
 
 from ..settings import ServerSettings
@@ -105,6 +105,16 @@ def split():
             time.sleep(0.5)
 
     return Response(event_stream(), mimetype="text/event-stream")
+
+
+@app.route("/<path:filename>")
+def serve_file(filename):
+    global notefile
+    assert isinstance(notefile, Path)
+
+    fld = notefile.parent
+                  
+    return send_from_directory(fld, filename)
 
 
 def get_notes(parent):

--- a/src/splitguides/server/split_server.py
+++ b/src/splitguides/server/split_server.py
@@ -113,7 +113,7 @@ def serve_file(filename):
     assert isinstance(notefile, Path)
 
     fld = notefile.parent
-                  
+
     return send_from_directory(fld, filename)
 
 


### PR DESCRIPTION
This makes splitguides server also serve files from the notes folder (but not any parent folders!) to allow linking images/videos from the host machine.